### PR TITLE
Upversion dependencies, and allow no custom-opts to be submitted.

### DIFF
--- a/example/src/reflecti/slider_example/db.cljs
+++ b/example/src/reflecti/slider_example/db.cljs
@@ -11,7 +11,7 @@
 (ns reflecti.slider-example.db
   (:require [reagent.core :as r]))
 
-(defonce slider-value (r/atom ""))
+(defonce slider-value (r/atom nil))
 
 (defn on-slide
   [_ value]

--- a/project.clj
+++ b/project.clj
@@ -8,18 +8,18 @@
 ;;   the terms of this license.
 ;;   You must not remove this notice, or any others, from this software.
 
-(defproject com.7theta/reflecti "0.1.5"
+(defproject com.7theta/reflecti "0.2.0"
   :description "A component library based on React"
   :url "https://github.com7theta/reflecti"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.8.0"]
-                 [org.clojure/clojurescript "1.9.89"]
+                 [org.clojure/clojurescript "1.9.93"]
 
-                 [com.7theta/utilis "0.7.0"]
+                 [com.7theta/utilis "0.8.0"]
                  [com.7theta/via "0.2.1"]
 
-                 [cljs-react-material-ui "0.2.12"]
+                 [cljs-react-material-ui "0.2.19"]
                  [reagent "0.6.0-alpha" :exclusions [org.clojure/tools.reader cljsjs/react]]
                  [re-frame "0.7.0"]
 
@@ -30,18 +30,17 @@
 
                  [prismatic/schema "1.1.2"]]
   :source-paths ["src/cljs"]
-  :plugins [[lein-cljsbuild "1.0.6"]
-            [lein-figwheel "0.3.3" :exclusions [cider/cider-nrepl
-                                                org.clojure/clojure]]]
+  :plugins [[lein-cljsbuild "1.1.3"]
+            [lein-figwheel "0.5.4-7" :exclusions [cider/cider-nrepl
+                                                  org.clojure/clojure]]]
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]
   :profiles {:dev {:source-paths ["dev" "example/src"]
                    :resource-paths ["example/resources"]
-                   :dependencies [[figwheel-sidecar "0.5.0-3"]
+                   :dependencies [[figwheel-sidecar "0.5.4-7"]
                                   [com.cemerick/piggieback "0.2.1"]]}}
   :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
   :cljsbuild {:builds [{:id "dev"
                         :source-paths ["src/cljs"]
-                        :resource-paths ["resources/public"]
                         :figwheel {:on-jsload "reflecti.example.core/mount-root"}
                         :warning-handlers [(fn [warning-type env extra]
                                              (when (warning-type cljs.analyzer/*cljs-warnings*)

--- a/src/cljs/reflecti/core.cljs
+++ b/src/cljs/reflecti/core.cljs
@@ -43,17 +43,17 @@
   [table/table data-source table-options])
 
 (defn search-drawer
-  [custom-opts]
+  [& [custom-opts]]
   [search-with-drawer/side-drawer-with-search custom-opts])
 
 (defn search-bar
-  [custom-opts]
+  [& [custom-opts]]
   [search/search-bar custom-opts])
 
 (defn slider
-  [custom-opts]
+  [& [custom-opts]]
   [slider/range-slider custom-opts])
 
 (defn date-time-picker
-  [custom-opts]
+  [& [custom-opts]]
   [picker/date-time-picker custom-opts])

--- a/src/cljs/reflecti/search.cljs
+++ b/src/cljs/reflecti/search.cljs
@@ -46,10 +46,11 @@
          default-style {:width 400
                         :margin-left 40
                         :height 48
-                        :zIndex 3}]
+                        :zIndex 3
+                        :zDepth 3}]
      [mui/mui-theme-provider
       {:mui-theme (ui/get-mui-theme theme)}
-      [mui/paper {:zDepth (or (:zIndex default-style) (:zIndex style))
+      [mui/paper {:zDepth (or (:zDepth style) (:zDepth default-style))
                   :style (merge default-style style)}
        [floating-search-bar (merge {:suggestions (map :display-text search-suggestions)
                                     :theme search-theme
@@ -238,7 +239,7 @@
                                  :onClick (fn [_]
                                             (when (not-empty text)
                                               (r/set-state this {:text ""})
-                                              (clear-fn)))
+                                              (when clear-fn (clear-fn))))
                                  :onMouseOver (fn [_] (r/set-state this {:clear-icon-hover true}))
                                  :onMouseOut (fn [_] (r/set-state this {:clear-icon-hover false}))})]
            (if (and show-suggestions

--- a/src/cljs/reflecti/slider.cljs
+++ b/src/cljs/reflecti/slider.cljs
@@ -37,7 +37,6 @@
     [mui/paper {:zDepth 3
                 :style style}
      [mui/slider {:style slider-style
-                  :tooltip "Time range"
                   :disableFocusRipple true
                   :onChange (fn [event value]
                               (when on-slide (on-slide event value)))}]]))


### PR DESCRIPTION
Upversion clojurescript, utilis, and cljs-react-material-ui in project.clj.
Ensure params on components in src/cljs/reflecti/core.cljs accepts nil when
no customization is desired. Allow customization to the zDepth of the
mui/paper component around src/cljs/reflecti/search.cljs, and make sure to only
call clear-fn if on-clear is passed in. Remove :tooltip from mui/slider in
src/cljs/reflecti/slider.cljs as it's an invalid prop.